### PR TITLE
Update http-adapter dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ Simple downloader usage:
 use Indigo\Flysystem\Downloader;
 use League\Flysystem\Filesystem;
 use Ivory\HttpAdapter\HttpAdapterInterface;
-use Psr\Http\Message\OutgoingRequestInterface;
+use Psr\Http\Message\RequestInterface;
 
 $downloader = new Downloader(new Filesystem, /* HttpAdapterInterface */);
 
-$request = /* OutgoingRequestInterface */;
+$request = /* RequestInterface */;
 
 $downloader->download($request, 'path/to/file');
 ```

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=5.4",
         "league/flysystem": "~1.0",
-        "egeloen/http-adapter": "0.6.*@dev"
+        "egeloen/http-adapter": "~0.7"
     },
     "require-dev": {
         "phpspec/phpspec": "~2.1",

--- a/spec/DownloaderSpec.php
+++ b/spec/DownloaderSpec.php
@@ -4,8 +4,8 @@ namespace spec\Indigo\Flysystem;
 
 use League\Flysystem\Filesystem;
 use Ivory\HttpAdapter\HttpAdapterInterface;
-use Psr\Http\Message\OutgoingRequestInterface as Request;
-use Psr\Http\Message\IncomingResponseInterface as Response;
+use Psr\Http\Message\RequestInterface as Request;
+use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\StreamableInterface as Stream;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;

--- a/src/Downloader.php
+++ b/src/Downloader.php
@@ -13,7 +13,7 @@ namespace Indigo\Flysystem;
 
 use League\Flysystem\Filesystem;
 use Ivory\HttpAdapter\HttpAdapterInterface;
-use Psr\Http\Message\OutgoingRequestInterface;
+use Psr\Http\Message\RequestInterface;
 
 /**
  * HTTP Downloader
@@ -45,11 +45,11 @@ class Downloader
     /**
      * Downloads a request
      *
-     * @param OutgoingRequestInterface $request
+     * @param RequestInterface $request
      *
      * @return boolean
      */
-    public function download(OutgoingRequestInterface $request, $path)
+    public function download(RequestInterface $request, $path)
     {
         $response = $this->httpAdapter->sendRequest($request);
 


### PR DESCRIPTION
One of my other packages required 'psr/http-message' ~1.0, so I couldn't install flysystem-http-downloader.

Update to be compatible with 'psr/http-message' ~1.0 (via 'egeloen/http-adapter' and 'phly/http')
